### PR TITLE
Update PdoServiceProvider.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "silex/silex": "^2.0"
+        "silex/silex": "^2.0",
+        "legow/reconnecting-pdo": "^1.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
+++ b/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
@@ -10,8 +10,9 @@ namespace LiquidBox\Silex\Provider;
 use PDO;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use LegoW\ReconnectingPDO;
 
-class PDOExt extends PDO
+class PDOExt extends ReconnectingPDO
 {
     protected $_table_prefix;
     public function __construct($dsn, $user = null, $password = null, $driver_options = array(), $prefix = null)

--- a/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
+++ b/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
@@ -204,8 +204,9 @@ class PdoServiceProvider implements ServiceProviderInterface
             $this->loadParameters($app);
 
             $instances = new Container();
-            foreach ($this->parameters as $connection => $this->args) {
-                $instances[$connection] = function () use ($app) {
+            foreach ($this->parameters as $connection => $args) {
+                $instances[$connection] = function () use ($app, $args) {
+                    $this->args = $args;
                     return $app['pdo.connect'](
                         $this->getArgDsn($app),
                         $this->getArg($app, 'username'),

--- a/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
+++ b/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
@@ -10,7 +10,7 @@ namespace LiquidBox\Silex\Provider;
 use PDO;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use LegoW\ReconnectingPDO;
+use LegoW\ReconnectingPDO\ReconnectingPDO;
 
 class PDOExt extends ReconnectingPDO
 {

--- a/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
+++ b/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
@@ -268,7 +268,7 @@ class PdoServiceProvider implements ServiceProviderInterface
             array $attributes = array(),
             $prefix = ''
         ) use ($app) {
-            $pdo = new PDO(
+            $pdo = new PDOExt(
                 is_array($dsn) ? $this->buildDsn($this->getDefaultArg($app, 'driver'), $dsn) : $dsn,
                 $username,
                 $password,

--- a/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
+++ b/src/LiquidBox/Silex/Provider/PdoServiceProvider.php
@@ -11,6 +11,42 @@ use PDO;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
+class PDOExt extends PDO
+{
+    protected $_table_prefix;
+    public function __construct($dsn, $user = null, $password = null, $driver_options = array(), $prefix = null)
+    {
+        $this->_table_prefix = $prefix ?? '';
+        parent::__construct($dsn, $user, $password, $driver_options);
+    }
+
+    public function exec($statement)
+    {
+        $statement = $this->_tablePrefix($statement);
+        return parent::exec($statement);
+    }
+    public function prepare($statement, $driver_options = array())
+    {
+        $statement = $this->_tablePrefix($statement);
+        return parent::prepare($statement, $driver_options);
+    }
+    public function query($statement)
+    {
+        $statement = $this->_tablePrefix($statement);
+        $args      = func_get_args();
+        if (count($args) > 1) {
+            return call_user_func_array(array($this, 'parent::query'), $args);
+        } else {
+            return parent::query($statement);
+        }
+    }
+    protected function _tablePrefix($statement)
+    {
+      $statement  = str_replace("prfx_", $this->_table_prefix, $statement);
+  		return $statement;
+    }
+}
+
 /**
  * PDO Provider.
  *
@@ -161,6 +197,9 @@ class PdoServiceProvider implements ServiceProviderInterface
         if (!empty($app['pdo.password'])) {
             $this->parameters[0]['password'] = $app['pdo.password'];
         }
+        if (!empty($app['pdo.prefix'])) {
+            $this->parameters[0]['prefix'] = $app['pdo.prefix'];
+        }
     }
 
     /**
@@ -212,7 +251,8 @@ class PdoServiceProvider implements ServiceProviderInterface
                         $this->getArg($app, 'username'),
                         $this->getArg($app, 'password'),
                         $this->getArg($app, 'options'),
-                        $this->getArg($app, 'attributes')
+                        $this->getArg($app, 'attributes'),
+                        $this->getArg($app, 'prefix')
                     );
                 };
             }
@@ -225,13 +265,15 @@ class PdoServiceProvider implements ServiceProviderInterface
             $username = '',
             $password = '',
             array $options = array(),
-            array $attributes = array()
+            array $attributes = array(),
+            $prefix = ''
         ) use ($app) {
             $pdo = new PDO(
                 is_array($dsn) ? $this->buildDsn($this->getDefaultArg($app, 'driver'), $dsn) : $dsn,
                 $username,
                 $password,
-                $options
+                $options,
+                $prefix
             );
             $this->setAttributes($pdo, $attributes);
 


### PR DESCRIPTION
Fixes a bug

With multiple connections with different drivers for each instance, a connection is created with arguments from the last element of the array.

Example:
$app->register(
    new LiquidBox\Silex\Provider\PdoServiceProvider(null, 'pdo.dbs'),
    array(
        'pdo.dsn' => array(
            'mysql_main' => array(
                'connection' => array(
                    'host'    => 'mysql_host',
                    'dbname'  => 'msqlexample',
                ),
                'username' => 'user',
                'password' => 'pass',
            ),
            'postgres_main' => array(
                'driver'     => 'pdo_pgsql',
                'connection' => array(
                    'host'    => 'postgres_host',
                    'dbname'  => 'psgexample'
                ),
                'username' => 'user',
                'password' => 'password',
            )
        )
    )
);

Result:
instances[mysql_main] = pgsql:host=postgres_host;dbname=psgexample
instances[postgres_main] = pgsql:host=postgres_host;dbname=psgexample